### PR TITLE
feat: 회원 기능 구현

### DIFF
--- a/src/main/java/ktb3/full/week04/annotation/resolver/Authentication.java
+++ b/src/main/java/ktb3/full/week04/annotation/resolver/Authentication.java
@@ -1,0 +1,11 @@
+package ktb3.full.week04.annotation.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authentication {
+}

--- a/src/main/java/ktb3/full/week04/annotation/resolver/AuthenticationArgumentResolver.java
+++ b/src/main/java/ktb3/full/week04/annotation/resolver/AuthenticationArgumentResolver.java
@@ -1,0 +1,32 @@
+package ktb3.full.week04.annotation.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static ktb3.full.week04.common.Constants.SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER;
+
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasParameterAnnotation = parameter.hasParameterAnnotation(Authentication.class);
+        boolean isAssignableFrom = ktb3.full.week04.dto.session.LoggedInUser.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasParameterAnnotation && isAssignableFrom;
+    }
+
+    @Nullable
+    @Override
+    public Object resolveArgument(MethodParameter parameter, @Nullable ModelAndViewContainer mavContainer, NativeWebRequest webRequest, @Nullable WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        HttpSession session = request.getSession(false);
+
+        return session.getAttribute(SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER);
+    }
+}

--- a/src/main/java/ktb3/full/week04/common/Constants.java
+++ b/src/main/java/ktb3/full/week04/common/Constants.java
@@ -1,0 +1,6 @@
+package ktb3.full.week04.common;
+
+public abstract class Constants {
+
+    public static final String SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER = "loggedInUser";
+}

--- a/src/main/java/ktb3/full/week04/config/WebConfig.java
+++ b/src/main/java/ktb3/full/week04/config/WebConfig.java
@@ -1,9 +1,13 @@
 package ktb3.full.week04.config;
 
+import ktb3.full.week04.annotation.resolver.AuthenticationArgumentResolver;
 import ktb3.full.week04.interceptor.LoginValidateInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -13,5 +17,10 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginValidateInterceptor())
                 .addPathPatterns("/**")
                 .excludePathPatterns("/users/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthenticationArgumentResolver());
     }
 }

--- a/src/main/java/ktb3/full/week04/config/WebConfig.java
+++ b/src/main/java/ktb3/full/week04/config/WebConfig.java
@@ -1,0 +1,17 @@
+package ktb3.full.week04.config;
+
+import ktb3.full.week04.interceptor.LoginValidateInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoginValidateInterceptor())
+                .addPathPatterns("/**")
+                .excludePathPatterns("/users/**");
+    }
+}

--- a/src/main/java/ktb3/full/week04/controller/AuthenticatedUserApiController.java
+++ b/src/main/java/ktb3/full/week04/controller/AuthenticatedUserApiController.java
@@ -1,11 +1,65 @@
 package ktb3.full.week04.controller;
 
+import jakarta.servlet.http.HttpSession;
+import ktb3.full.week04.dto.request.UserAccountUpdateRequest;
+import ktb3.full.week04.dto.request.UserPasswordUpdateRequest;
+import ktb3.full.week04.dto.response.ApiResponse;
+import ktb3.full.week04.dto.session.LoggedInUser;
+import ktb3.full.week04.dto.response.UserAccountResponse;
+import ktb3.full.week04.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static ktb3.full.week04.common.Constants.SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER;
 
 @RequiredArgsConstructor
 @RequestMapping("/user")
 @RestController
 public class AuthenticatedUserApiController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserAccountResponse>> getUserAccount(
+            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser) {
+        UserAccountResponse userAccountResponse = userService.getUserAccount(loggedInUser.getUserId());
+        return ResponseEntity.ok()
+                .body(ApiResponse.of(userAccountResponse));
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse<Void>> updateUserAccount(
+            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser,
+            @RequestBody UserAccountUpdateRequest userAccountUpdateRequest) {
+        userService.updateAccount(loggedInUser.getUserId(), userAccountUpdateRequest);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(
+            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser,
+            @RequestBody UserPasswordUpdateRequest userPasswordUpdateRequest) {
+        userService.updatePassword(loggedInUser.getUserId(), userPasswordUpdateRequest);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpSession session) {
+        session.invalidate();
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> deleteUserAccount(
+            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser,
+            HttpSession session) {
+        userService.deleteAccount(loggedInUser.getUserId());
+        session.invalidate();
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
 }

--- a/src/main/java/ktb3/full/week04/controller/AuthenticatedUserApiController.java
+++ b/src/main/java/ktb3/full/week04/controller/AuthenticatedUserApiController.java
@@ -1,17 +1,16 @@
 package ktb3.full.week04.controller;
 
 import jakarta.servlet.http.HttpSession;
+import ktb3.full.week04.annotation.resolver.Authentication;
 import ktb3.full.week04.dto.request.UserAccountUpdateRequest;
 import ktb3.full.week04.dto.request.UserPasswordUpdateRequest;
 import ktb3.full.week04.dto.response.ApiResponse;
-import ktb3.full.week04.dto.session.LoggedInUser;
 import ktb3.full.week04.dto.response.UserAccountResponse;
+import ktb3.full.week04.dto.session.LoggedInUser;
 import ktb3.full.week04.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static ktb3.full.week04.common.Constants.SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER;
 
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -21,8 +20,7 @@ public class AuthenticatedUserApiController {
     private final UserService userService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<UserAccountResponse>> getUserAccount(
-            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser) {
+    public ResponseEntity<ApiResponse<UserAccountResponse>> getUserAccount(@Authentication LoggedInUser loggedInUser) {
         UserAccountResponse userAccountResponse = userService.getUserAccount(loggedInUser.getUserId());
         return ResponseEntity.ok()
                 .body(ApiResponse.of(userAccountResponse));
@@ -30,7 +28,7 @@ public class AuthenticatedUserApiController {
 
     @PatchMapping
     public ResponseEntity<ApiResponse<Void>> updateUserAccount(
-            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser,
+            @Authentication LoggedInUser loggedInUser,
             @RequestBody UserAccountUpdateRequest userAccountUpdateRequest) {
         userService.updateAccount(loggedInUser.getUserId(), userAccountUpdateRequest);
         return ResponseEntity.ok()
@@ -39,7 +37,7 @@ public class AuthenticatedUserApiController {
 
     @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
-            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser,
+            @Authentication LoggedInUser loggedInUser,
             @RequestBody UserPasswordUpdateRequest userPasswordUpdateRequest) {
         userService.updatePassword(loggedInUser.getUserId(), userPasswordUpdateRequest);
         return ResponseEntity.ok()
@@ -54,9 +52,7 @@ public class AuthenticatedUserApiController {
     }
 
     @DeleteMapping
-    public ResponseEntity<ApiResponse<Void>> deleteUserAccount(
-            @SessionAttribute(name = SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) LoggedInUser loggedInUser,
-            HttpSession session) {
+    public ResponseEntity<ApiResponse<Void>> deleteUserAccount(@Authentication LoggedInUser loggedInUser, HttpSession session) {
         userService.deleteAccount(loggedInUser.getUserId());
         session.invalidate();
         return ResponseEntity.ok()

--- a/src/main/java/ktb3/full/week04/controller/UserApiController.java
+++ b/src/main/java/ktb3/full/week04/controller/UserApiController.java
@@ -1,11 +1,50 @@
 package ktb3.full.week04.controller;
 
+import jakarta.servlet.http.HttpSession;
+import ktb3.full.week04.dto.request.UserLoginRequest;
+import ktb3.full.week04.dto.request.UserRegisterRequest;
+import ktb3.full.week04.dto.response.ApiResponse;
+import ktb3.full.week04.dto.session.LoggedInUser;
+import ktb3.full.week04.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static ktb3.full.week04.common.Constants.SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER;
 
 @RequiredArgsConstructor
 @RequestMapping("/users")
 @RestController
 public class UserApiController {
 
+    private final UserService userService;
+
+    @GetMapping("/email-validation")
+    public ResponseEntity<ApiResponse<Boolean>> validateEmailAvailable(@RequestParam("email") String email) {
+        boolean available = userService.validateEmailAvailable(email);
+        return ResponseEntity.ok()
+                .body(ApiResponse.of(available));
+    }
+
+    @GetMapping("/nickname-validation")
+    public ResponseEntity<ApiResponse<Boolean>> validateNicknameAvailable(@RequestParam("nickname") String nickname) {
+        boolean available = userService.validateNicknameAvailable(nickname);
+        return ResponseEntity.ok()
+                .body(ApiResponse.of(available));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody UserRegisterRequest userRegisterRequest) {
+        userService.register(userRegisterRequest);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@RequestBody UserLoginRequest userLoginRequest, HttpSession session) {
+        LoggedInUser loggedInUser = userService.login(userLoginRequest);
+        session.setAttribute(SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER, loggedInUser);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
 }

--- a/src/main/java/ktb3/full/week04/domain/User.java
+++ b/src/main/java/ktb3/full/week04/domain/User.java
@@ -31,4 +31,24 @@ public class User extends Auditing {
     public void save(Long userId) {
         this.userId = userId;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+        this.auditUpdate();
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+        this.auditUpdate();
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+        this.auditUpdate();
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.auditDelete();
+    }
 }

--- a/src/main/java/ktb3/full/week04/domain/User.java
+++ b/src/main/java/ktb3/full/week04/domain/User.java
@@ -27,4 +27,8 @@ public class User extends Auditing {
                 .isDeleted(false)
                 .build();
     }
+
+    public void save(Long userId) {
+        this.userId = userId;
+    }
 }

--- a/src/main/java/ktb3/full/week04/dto/request/UserLoginRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserLoginRequest.java
@@ -1,4 +1,12 @@
 package ktb3.full.week04.dto.request;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public class UserLoginRequest {
+
+    private final String email;
+    private final String password;
 }

--- a/src/main/java/ktb3/full/week04/dto/request/UserPasswordUpdateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserPasswordUpdateRequest.java
@@ -5,9 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class UserAccountUpdateRequest {
+public class UserPasswordUpdateRequest {
 
-    private final String nickname;
     private final String password;
-    private final String profileImage;
 }

--- a/src/main/java/ktb3/full/week04/dto/request/UserRegisterRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserRegisterRequest.java
@@ -1,4 +1,19 @@
 package ktb3.full.week04.dto.request;
 
+import ktb3.full.week04.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public class UserRegisterRequest {
+
+    private final String email;
+    private final String password;
+    private final String nickname;
+    private final String profileImage;
+
+    public User toEntity() {
+        return User.create(email, password, nickname, profileImage);
+    }
 }

--- a/src/main/java/ktb3/full/week04/dto/response/UserAccountResponse.java
+++ b/src/main/java/ktb3/full/week04/dto/response/UserAccountResponse.java
@@ -1,4 +1,18 @@
 package ktb3.full.week04.dto.response;
 
+import ktb3.full.week04.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public class UserAccountResponse {
+
+    private final String email;
+    private final String nickname;
+    private final String profileImage;
+
+    public static UserAccountResponse from(User user) {
+        return new UserAccountResponse(user.getEmail(), user.getNickname(), user.getProfileImage());
+    }
 }

--- a/src/main/java/ktb3/full/week04/dto/session/LoggedInUser.java
+++ b/src/main/java/ktb3/full/week04/dto/session/LoggedInUser.java
@@ -1,0 +1,17 @@
+package ktb3.full.week04.dto.session;
+
+import ktb3.full.week04.domain.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoggedInUser {
+
+    private final long userId;
+
+    public static LoggedInUser from(User user) {
+        return new LoggedInUser(user.getUserId());
+    }
+}

--- a/src/main/java/ktb3/full/week04/interceptor/LoginValidateInterceptor.java
+++ b/src/main/java/ktb3/full/week04/interceptor/LoginValidateInterceptor.java
@@ -1,0 +1,22 @@
+package ktb3.full.week04.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import ktb3.full.week04.exception.LoginRequiredException;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static ktb3.full.week04.common.Constants.SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER;
+
+public class LoginValidateInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute(SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER) == null) {
+            throw new LoginRequiredException();
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/ktb3/full/week04/repository/UserRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/UserRepository.java
@@ -13,7 +13,9 @@ public interface UserRepository {
 
     Optional<User> findById(Long userId);
 
+    Optional<User> findByEmail(String email);
+
     void update(User user);
 
-    void delete(Long userId);
+    void delete(User user);
 }

--- a/src/main/java/ktb3/full/week04/repository/impl/UserMemoryRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/impl/UserMemoryRepository.java
@@ -1,0 +1,80 @@
+package ktb3.full.week04.repository.impl;
+
+import ktb3.full.week04.domain.User;
+import ktb3.full.week04.repository.UserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class UserMemoryRepository implements UserRepository {
+
+    private final AtomicLong userIdCounter = new AtomicLong(1L);
+
+    private final Map<Long, User> idToUser = new ConcurrentHashMap<>();
+    private final Map<String, Long> emailToId = new ConcurrentHashMap<>();
+    private final Map<String, Long> nicknameToId = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return emailToId.containsKey(email);
+    }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        return nicknameToId.containsKey(nickname);
+    }
+
+    @Override
+    public void save(User user) {
+        long userId = userIdCounter.getAndIncrement();
+        user.save(userId);
+
+        idToUser.put(userId, user);
+        emailToId.put(user.getEmail(), userId);
+        nicknameToId.put(user.getNickname(), userId);
+    }
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        User user = idToUser.get(userId);
+
+        if (user == null || user.isDeleted()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(user);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        Long userId = emailToId.get(email);
+
+        if (userId == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(idToUser.get(userId));
+    }
+
+    @Override
+    public void update(User user) {
+        User existing = idToUser.get(user.getUserId());
+        idToUser.put(user.getUserId(), user);
+
+        if (!existing.getNickname().equals(user.getNickname())) {
+            nicknameToId.remove(existing.getNickname());
+            nicknameToId.put(user.getNickname(), user.getUserId());
+        }
+    }
+
+    @Override
+    public void delete(User user) {
+        idToUser.remove(user.getUserId());
+        emailToId.remove(user.getEmail());
+        nicknameToId.remove(user.getNickname());
+    }
+}

--- a/src/main/java/ktb3/full/week04/repository/impl/UserMemoryRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/impl/UserMemoryRepository.java
@@ -41,12 +41,7 @@ public class UserMemoryRepository implements UserRepository {
     @Override
     public Optional<User> findById(Long userId) {
         User user = idToUser.get(userId);
-
-        if (user == null || user.isDeleted()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(user);
+        return validateUser(user);
     }
 
     @Override
@@ -57,7 +52,7 @@ public class UserMemoryRepository implements UserRepository {
             return Optional.empty();
         }
 
-        return Optional.ofNullable(idToUser.get(userId));
+        return validateUser(idToUser.get(userId));
     }
 
     @Override
@@ -76,5 +71,13 @@ public class UserMemoryRepository implements UserRepository {
         idToUser.remove(user.getUserId());
         emailToId.remove(user.getEmail());
         nicknameToId.remove(user.getNickname());
+    }
+
+    private static Optional<User> validateUser(User user) {
+        if (user == null || user.isDeleted()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(user);
     }
 }

--- a/src/main/java/ktb3/full/week04/service/UserService.java
+++ b/src/main/java/ktb3/full/week04/service/UserService.java
@@ -2,22 +2,26 @@ package ktb3.full.week04.service;
 
 import ktb3.full.week04.dto.request.UserAccountUpdateRequest;
 import ktb3.full.week04.dto.request.UserLoginRequest;
+import ktb3.full.week04.dto.request.UserPasswordUpdateRequest;
 import ktb3.full.week04.dto.request.UserRegisterRequest;
+import ktb3.full.week04.dto.session.LoggedInUser;
 import ktb3.full.week04.dto.response.UserAccountResponse;
 
 public interface UserService {
 
-    boolean validateEmailDuplication(String email);
+    boolean validateEmailAvailable(String email);
 
-    boolean validateNicknameDuplication(String nickname);
+    boolean validateNicknameAvailable(String nickname);
 
     void register(UserRegisterRequest request);
 
-    void login(UserLoginRequest request);
+    LoggedInUser login(UserLoginRequest request);
 
     UserAccountResponse getUserAccount(Long userId);
 
     void updateAccount(Long userId, UserAccountUpdateRequest request);
+
+    void updatePassword(Long userId, UserPasswordUpdateRequest request);
 
     void deleteAccount(Long userId);
 }

--- a/src/main/java/ktb3/full/week04/service/impl/UserServiceImpl.java
+++ b/src/main/java/ktb3/full/week04/service/impl/UserServiceImpl.java
@@ -1,0 +1,104 @@
+package ktb3.full.week04.service.impl;
+
+import ktb3.full.week04.domain.User;
+import ktb3.full.week04.dto.request.UserAccountUpdateRequest;
+import ktb3.full.week04.dto.request.UserLoginRequest;
+import ktb3.full.week04.dto.request.UserPasswordUpdateRequest;
+import ktb3.full.week04.dto.request.UserRegisterRequest;
+import ktb3.full.week04.dto.session.LoggedInUser;
+import ktb3.full.week04.dto.response.UserAccountResponse;
+import ktb3.full.week04.exception.DuplicatedEmailException;
+import ktb3.full.week04.exception.DuplicatedNicknameException;
+import ktb3.full.week04.exception.InvalidCredentialsException;
+import ktb3.full.week04.exception.UserNotFoundException;
+import ktb3.full.week04.repository.UserRepository;
+import ktb3.full.week04.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean validateEmailAvailable(String email) {
+        return !userRepository.existsByEmail(email);
+    }
+
+    @Override
+    public boolean validateNicknameAvailable(String nickname) {
+        return !userRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public void register(UserRegisterRequest request) {
+        validateEmailDuplication(request.getEmail());
+        validateNicknameDuplication(request.getNickname());
+
+        userRepository.save(request.toEntity());
+    }
+
+    @Override
+    public LoggedInUser login(UserLoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (!user.getPassword().equals(request.getPassword())) {
+            throw new InvalidCredentialsException();
+        }
+
+        return LoggedInUser.from(user);
+    }
+
+    @Override
+    public UserAccountResponse getUserAccount(Long userId) {
+        User user = getUserOrThrow(userId);
+        return UserAccountResponse.from(user);
+    }
+
+    @Override
+    public void updateAccount(Long userId, UserAccountUpdateRequest request) {
+        User user = getUserOrThrow(userId);
+        validateNicknameDuplication(request.getNickname());
+        user.updateNickname(request.getNickname());
+        user.updateProfileImage(request.getProfileImage());
+
+        userRepository.update(user);
+    }
+
+    @Override
+    public void updatePassword(Long userId, UserPasswordUpdateRequest request) {
+        User user = getUserOrThrow(userId);
+        user.updatePassword(request.getPassword());
+
+        userRepository.update(user);
+    }
+
+    @Override
+    public void deleteAccount(Long userId) {
+        // soft delete
+        User user = getUserOrThrow(userId);
+        user.delete();
+
+        userRepository.update(user);
+    }
+
+    public User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private void validateEmailDuplication(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicatedEmailException();
+        }
+    }
+
+    private void validateNicknameDuplication(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new DuplicatedNicknameException();
+        }
+    }
+}


### PR DESCRIPTION
### 작업 내용
- Repository 구현
  - 메모리에서 데이터를 관리해야 하므로 PK로 빠르게 접근할 수 있는 `Map`을 사용했습니다.
  - 이메일, 닉네임으로 검색할 수 있어야 하므로 추가 저장소를 생성했습니다.
  - PK는 Auto Increment로 구현했고, Thread-safe를 위해 `AtomicLong` 타입을 사용했습니다.
  - `Map` 구현체는 Thread-safe를 위해 `ConcurrentHashMap`을 사용했습니다.
- Service 구현
  -  회원탈퇴는 Soft Delete 방식으로 구현했습니다.
- Controller 구현
  - 로그인 시 세션을 생성하고 로그아웃, 회원탈퇴 시 세션을 무효화합니다.
- 사용자 세션 관리
  - 코드 중복을 줄이기 위해 Argument Resolver를 구현했습니다.
  - 인터셉터에서 인증 로직을 수행합니다.
  - 세션의 크기를 줄이기 위해 최소한의 정보(`userId`)만 저장합니다.