### PR TITLE
feat: 회원 데이터 유효성 검증

### DIFF
--- a/src/main/java/ktb3/full/week04/common/Constants.java
+++ b/src/main/java/ktb3/full/week04/common/Constants.java
@@ -2,5 +2,11 @@ package ktb3.full.week04.common;
 
 public abstract class Constants {
 
+    // Session Attribute Name
     public static final String SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER = "loggedInUser";
+
+    // Message
+    public static final String MESSAGE_NOT_NULL_EMAIL = "이메일을 입력해주세요.";
+    public static final String MESSAGE_NOT_NULL_NICKNAME = "닉네임을 입력해주세요.";
+    public static final String MESSAGE_NOT_NULL_PASSWORD = "비밀번호를 입력해주세요.";
 }

--- a/src/main/java/ktb3/full/week04/common/annotation/constraint/EmailPattern.java
+++ b/src/main/java/ktb3/full/week04/common/annotation/constraint/EmailPattern.java
@@ -1,0 +1,23 @@
+package ktb3.full.week04.common.annotation.constraint;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.*;
+
+@Pattern(regexp = "^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$")
+@ReportAsSingleViolation
+@Documented
+@Constraint(validatedBy = { })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailPattern {
+
+    String message() default "올바른 이메일 주소 형식을 입력해주세요. (예: example@example.com)";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/ktb3/full/week04/common/annotation/constraint/NicknamePattern.java
+++ b/src/main/java/ktb3/full/week04/common/annotation/constraint/NicknamePattern.java
@@ -1,0 +1,23 @@
+package ktb3.full.week04.common.annotation.constraint;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.*;
+
+@Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,10}$")
+@ReportAsSingleViolation
+@Documented
+@Constraint(validatedBy = { })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NicknamePattern {
+
+    String message() default "올바른 닉네임 형식을 입력해주세요. (한글, 영어, 숫자만 포함하고 공백 없이 1~10자 사이여야 합니다.)";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/ktb3/full/week04/common/annotation/constraint/PasswordPattern.java
+++ b/src/main/java/ktb3/full/week04/common/annotation/constraint/PasswordPattern.java
@@ -1,0 +1,23 @@
+package ktb3.full.week04.common.annotation.constraint;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.*;
+
+@Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+]).{8,20}$")
+@ReportAsSingleViolation
+@Documented
+@Constraint(validatedBy = { })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PasswordPattern {
+
+    String message() default "올바른 비밀번호 형식을 입력해주세요. (대문자, 소문자, 숫자, 특수문자를 각각 최소 1개 포함하고 8~20자 사이여야 합니다.)";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/ktb3/full/week04/common/exception/ApiErrorCode.java
+++ b/src/main/java/ktb3/full/week04/common/exception/ApiErrorCode.java
@@ -12,6 +12,7 @@ public enum ApiErrorCode {
     HTTP_MESSAGE_NOT_READABLE("4002", "요청 본문의 형식이 올바르지 않습니다."),
     MISSING_SERVLET_REQUEST_PARAMETER("4003", "필수 요청 파라미터가 누락되었습니다."),
     METHOD_ARGUMENT_TYPE_MISMATCH("4004", "요청 파라미터의 타입이 올바르지 않습니다."),
+    CONSTRAINT_VIOLATION("4005", "요청 파라미터의 값이 올바르지 않습니다."),
 
     // 401 Unauthorized
     INVALID_CREDENTIALS("4011", "아이디 또는 비밀번호가 틀렸습니다."),

--- a/src/main/java/ktb3/full/week04/dto/request/UserAccountUpdateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserAccountUpdateRequest.java
@@ -1,5 +1,6 @@
 package ktb3.full.week04.dto.request;
 
+import ktb3.full.week04.common.annotation.constraint.NicknamePattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserAccountUpdateRequest {
 
+    @NicknamePattern
     private final String nickname;
-    private final String password;
+
     private final String profileImage;
 }

--- a/src/main/java/ktb3/full/week04/dto/request/UserLoginRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserLoginRequest.java
@@ -1,12 +1,23 @@
 package ktb3.full.week04.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import ktb3.full.week04.common.annotation.constraint.EmailPattern;
+import ktb3.full.week04.common.annotation.constraint.PasswordPattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import static ktb3.full.week04.common.Constants.MESSAGE_NOT_NULL_EMAIL;
+import static ktb3.full.week04.common.Constants.MESSAGE_NOT_NULL_PASSWORD;
 
 @Getter
 @RequiredArgsConstructor
 public class UserLoginRequest {
 
+    @NotNull(message = MESSAGE_NOT_NULL_EMAIL)
+    @EmailPattern
     private final String email;
+
+    @NotNull(message = MESSAGE_NOT_NULL_PASSWORD)
+    @PasswordPattern
     private final String password;
 }

--- a/src/main/java/ktb3/full/week04/dto/request/UserPasswordUpdateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserPasswordUpdateRequest.java
@@ -1,11 +1,17 @@
 package ktb3.full.week04.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import ktb3.full.week04.common.annotation.constraint.PasswordPattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import static ktb3.full.week04.common.Constants.MESSAGE_NOT_NULL_PASSWORD;
 
 @Getter
 @RequiredArgsConstructor
 public class UserPasswordUpdateRequest {
 
+    @NotNull(message = MESSAGE_NOT_NULL_PASSWORD)
+    @PasswordPattern
     private final String password;
 }

--- a/src/main/java/ktb3/full/week04/dto/request/UserRegisterRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/UserRegisterRequest.java
@@ -1,16 +1,33 @@
 package ktb3.full.week04.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import ktb3.full.week04.common.annotation.constraint.EmailPattern;
+import ktb3.full.week04.common.annotation.constraint.NicknamePattern;
+import ktb3.full.week04.common.annotation.constraint.PasswordPattern;
 import ktb3.full.week04.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
+import static ktb3.full.week04.common.Constants.*;
+
+@ToString
 @Getter
 @RequiredArgsConstructor
 public class UserRegisterRequest {
 
+    @NotNull(message = MESSAGE_NOT_NULL_EMAIL)
+    @EmailPattern
     private final String email;
+
+    @NotNull(message = MESSAGE_NOT_NULL_PASSWORD)
+    @PasswordPattern
     private final String password;
+
+    @NotNull(message = MESSAGE_NOT_NULL_NICKNAME)
+    @NicknamePattern
     private final String nickname;
+
     private final String profileImage;
 
     public User toEntity() {

--- a/src/main/java/ktb3/full/week04/presentation/controller/AuthenticatedUserApiController.java
+++ b/src/main/java/ktb3/full/week04/presentation/controller/AuthenticatedUserApiController.java
@@ -1,6 +1,7 @@
 package ktb3.full.week04.presentation.controller;
 
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import ktb3.full.week04.common.annotation.resolver.Authentication;
 import ktb3.full.week04.dto.request.UserAccountUpdateRequest;
 import ktb3.full.week04.dto.request.UserPasswordUpdateRequest;
@@ -29,7 +30,7 @@ public class AuthenticatedUserApiController {
     @PatchMapping
     public ResponseEntity<ApiResponse<Void>> updateUserAccount(
             @Authentication LoggedInUser loggedInUser,
-            @RequestBody UserAccountUpdateRequest userAccountUpdateRequest) {
+            @Valid @RequestBody UserAccountUpdateRequest userAccountUpdateRequest) {
         userService.updateAccount(loggedInUser.getUserId(), userAccountUpdateRequest);
         return ResponseEntity.ok()
                 .body(ApiResponse.getBaseResponse());
@@ -38,7 +39,7 @@ public class AuthenticatedUserApiController {
     @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
             @Authentication LoggedInUser loggedInUser,
-            @RequestBody UserPasswordUpdateRequest userPasswordUpdateRequest) {
+            @Valid @RequestBody UserPasswordUpdateRequest userPasswordUpdateRequest) {
         userService.updatePassword(loggedInUser.getUserId(), userPasswordUpdateRequest);
         return ResponseEntity.ok()
                 .body(ApiResponse.getBaseResponse());

--- a/src/main/java/ktb3/full/week04/presentation/controller/UserApiController.java
+++ b/src/main/java/ktb3/full/week04/presentation/controller/UserApiController.java
@@ -1,6 +1,9 @@
 package ktb3.full.week04.presentation.controller;
 
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import ktb3.full.week04.common.annotation.constraint.EmailPattern;
+import ktb3.full.week04.common.annotation.constraint.NicknamePattern;
 import ktb3.full.week04.dto.request.UserLoginRequest;
 import ktb3.full.week04.dto.request.UserRegisterRequest;
 import ktb3.full.week04.dto.response.ApiResponse;
@@ -8,10 +11,12 @@ import ktb3.full.week04.dto.session.LoggedInUser;
 import ktb3.full.week04.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import static ktb3.full.week04.common.Constants.SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER;
 
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/users")
 @RestController
@@ -20,28 +25,28 @@ public class UserApiController {
     private final UserService userService;
 
     @GetMapping("/email-validation")
-    public ResponseEntity<ApiResponse<Boolean>> validateEmailAvailable(@RequestParam("email") String email) {
+    public ResponseEntity<ApiResponse<Boolean>> validateEmailAvailable(@EmailPattern @RequestParam("email") String email) {
         boolean available = userService.validateEmailAvailable(email);
         return ResponseEntity.ok()
                 .body(ApiResponse.of(available));
     }
 
     @GetMapping("/nickname-validation")
-    public ResponseEntity<ApiResponse<Boolean>> validateNicknameAvailable(@RequestParam("nickname") String nickname) {
+    public ResponseEntity<ApiResponse<Boolean>> validateNicknameAvailable(@NicknamePattern @RequestParam("nickname") String nickname) {
         boolean available = userService.validateNicknameAvailable(nickname);
         return ResponseEntity.ok()
                 .body(ApiResponse.of(available));
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody UserRegisterRequest userRegisterRequest) {
+    public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody UserRegisterRequest userRegisterRequest) {
         userService.register(userRegisterRequest);
         return ResponseEntity.ok()
                 .body(ApiResponse.getBaseResponse());
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(@RequestBody UserLoginRequest userLoginRequest, HttpSession session) {
+    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody UserLoginRequest userLoginRequest, HttpSession session) {
         LoggedInUser loggedInUser = userService.login(userLoginRequest);
         session.setAttribute(SESSION_ATTRIBUTE_NAME_LOGGED_IN_USER, loggedInUser);
         return ResponseEntity.ok()

--- a/src/main/java/ktb3/full/week04/presentation/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ktb3/full/week04/presentation/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package ktb3.full.week04.presentation.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import ktb3.full.week04.common.exception.ApiErrorCode;
 import ktb3.full.week04.dto.response.ApiErrorResponse;
 import ktb3.full.week04.common.exception.base.CustomException;
@@ -51,9 +52,15 @@ public class GlobalExceptionHandler {
                 .body(ApiErrorResponse.ofDetail(ApiErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH, e.getMessage(), request.getRequestURI()));
     }
 
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(HttpServletRequest request, ConstraintViolationException e) {
+        return ResponseEntity.badRequest()
+                .body(ApiErrorResponse.ofDetail(ApiErrorCode.CONSTRAINT_VIOLATION, e.getMessage(), request.getRequestURI()));
+    }
+
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ApiErrorResponse> handleNoResourceFoundException(HttpServletRequest request, NoResourceFoundException e) {
-        return ResponseEntity.badRequest()
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ApiErrorResponse.of(ApiErrorCode.NO_RESOURCE_FOUND, request.getRequestURI()));
     }
 

--- a/src/main/java/ktb3/full/week04/service/impl/UserServiceImpl.java
+++ b/src/main/java/ktb3/full/week04/service/impl/UserServiceImpl.java
@@ -61,9 +61,12 @@ public class UserServiceImpl implements UserService {
     @Override
     public void updateAccount(Long userId, UserAccountUpdateRequest request) {
         User user = getUserOrThrow(userId);
-        validateNicknameDuplication(request.getNickname());
-        user.updateNickname(request.getNickname());
         user.updateProfileImage(request.getProfileImage());
+
+        if (request.getNickname() != null) {
+            validateNicknameDuplication(request.getNickname());
+            user.updateNickname(request.getNickname());
+        }
 
         userRepository.update(user);
     }


### PR DESCRIPTION
### 작업 내용
- 회원 제약 조건 어노테이션 생성
  - 회원 이메일, 닉네임, 비밀번호의 패턴 제약 조건을 재사용하기 위해 어노테이션을 생성했습니다.
- UserServiceImpl 회원 정보 수정 로직 수정
  - 요청 DTO에서 닉네임이 필수 입력값이 아니기 때문에 이를 검증하도록 수정했습니다.
- ConstraintViolationException 예외 핸들러 생성
  - 요청 파라미터 값이 유효성 검증에 실패할 때 발생하는 예외를 처리합니다.