### PR TITLE
feat: 댓글 기능 구현

### DIFF
--- a/src/main/java/ktb3/full/week04/common/Constants.java
+++ b/src/main/java/ktb3/full/week04/common/Constants.java
@@ -11,6 +11,7 @@ public abstract class Constants {
     public static final String MESSAGE_NOT_NULL_PASSWORD = "비밀번호를 입력해주세요.";
     public static final String MESSAGE_NOT_NULL_POST_TITLE = "제목을 입력해주세요.";
     public static final String MESSAGE_NOT_NULL_POST_CONTENT = "내용을 입력해주세요.";
+    public static final String MESSAGE_NOT_NULL_COMMENT_CONTENT = "내용을 입력해주세요.";
 
     public static final String MESSAGE_EMAIL_PATTERN = "올바른 이메일 주소 형식을 입력해주세요. (예: example@example.com)";
     public static final String MESSAGE_NICKNAME_PATTERN = "올바른 닉네임 형식을 입력해주세요. (한글, 영어, 숫자만 포함하고 공백 없이 1~10자 사이여야 합니다.)";

--- a/src/main/java/ktb3/full/week04/common/annotation/constraint/CommentContentPattern.java
+++ b/src/main/java/ktb3/full/week04/common/annotation/constraint/CommentContentPattern.java
@@ -1,0 +1,25 @@
+package ktb3.full.week04.common.annotation.constraint;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.*;
+
+import static ktb3.full.week04.common.Constants.MESSAGE_NOT_NULL_COMMENT_CONTENT;
+
+@Pattern(regexp = "^(?=.*\\S).+$")
+@ReportAsSingleViolation
+@Documented
+@Constraint(validatedBy = { })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CommentContentPattern {
+
+    String message() default MESSAGE_NOT_NULL_COMMENT_CONTENT;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/ktb3/full/week04/domain/Comment.java
+++ b/src/main/java/ktb3/full/week04/domain/Comment.java
@@ -28,4 +28,13 @@ public class Comment extends Auditing {
     public void save(long commentId) {
         this.commentId = commentId;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+        this.auditUpdate();
+    }
+
+    public void delete() {
+        this.auditDelete();
+    }
 }

--- a/src/main/java/ktb3/full/week04/domain/Comment.java
+++ b/src/main/java/ktb3/full/week04/domain/Comment.java
@@ -15,7 +15,6 @@ public class Comment extends Auditing {
     private final User user;
     private final Post post;
     private String content;
-    private boolean isDeleted;
 
     public static Comment create(User user, Post post, String content) {
         return Comment.builder()
@@ -23,7 +22,6 @@ public class Comment extends Auditing {
                 .user(user)
                 .post(post)
                 .content(content)
-                .isDeleted(false)
                 .build();
     }
 

--- a/src/main/java/ktb3/full/week04/domain/Comment.java
+++ b/src/main/java/ktb3/full/week04/domain/Comment.java
@@ -1,5 +1,6 @@
 package ktb3.full.week04.domain;
 
+import ktb3.full.week04.domain.base.Auditing;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,5 +25,9 @@ public class Comment extends Auditing {
                 .content(content)
                 .isDeleted(false)
                 .build();
+    }
+
+    public void save(long commentId) {
+        this.commentId = commentId;
     }
 }

--- a/src/main/java/ktb3/full/week04/domain/Post.java
+++ b/src/main/java/ktb3/full/week04/domain/Post.java
@@ -19,7 +19,6 @@ public class Post extends Auditing {
     private int likeCount;
     private int commentCount;
     private int viewCount;
-    private boolean isDeleted;
 
     public static Post create(User user, String title, String content, String image) {
         return Post.builder()
@@ -31,7 +30,6 @@ public class Post extends Auditing {
                 .likeCount(0)
                 .commentCount(0)
                 .viewCount(0)
-                .isDeleted(false)
                 .build();
     }
 
@@ -71,7 +69,6 @@ public class Post extends Auditing {
     }
 
     public void delete() {
-        this.isDeleted = true;
         this.auditDelete();
     }
 }

--- a/src/main/java/ktb3/full/week04/domain/Post.java
+++ b/src/main/java/ktb3/full/week04/domain/Post.java
@@ -1,5 +1,6 @@
 package ktb3.full.week04.domain;
 
+import ktb3.full.week04.domain.base.Auditing;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/ktb3/full/week04/domain/User.java
+++ b/src/main/java/ktb3/full/week04/domain/User.java
@@ -1,5 +1,6 @@
 package ktb3.full.week04.domain;
 
+import ktb3.full.week04.domain.base.Auditing;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/ktb3/full/week04/domain/User.java
+++ b/src/main/java/ktb3/full/week04/domain/User.java
@@ -16,7 +16,6 @@ public class User extends Auditing {
     private String password;
     private String nickname;
     private String profileImage;
-    private boolean isDeleted;
 
     public static User create(String email, String password, String nickname, String profileImage) {
         return User.builder()
@@ -25,7 +24,6 @@ public class User extends Auditing {
                 .password(password)
                 .nickname(nickname)
                 .profileImage(profileImage)
-                .isDeleted(false)
                 .build();
     }
 
@@ -49,7 +47,6 @@ public class User extends Auditing {
     }
 
     public void delete() {
-        this.isDeleted = true;
         this.auditDelete();
     }
 }

--- a/src/main/java/ktb3/full/week04/domain/base/Auditing.java
+++ b/src/main/java/ktb3/full/week04/domain/base/Auditing.java
@@ -3,15 +3,18 @@ package ktb3.full.week04.domain.base;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 public abstract class Auditing {
 
+    private boolean isDeleted;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
     protected Auditing() {
+        this.isDeleted = false;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
@@ -21,7 +24,16 @@ public abstract class Auditing {
     }
 
     public void auditDelete() {
+        this.isDeleted = true;
         this.updatedAt = LocalDateTime.now();
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public static <T extends Auditing> Optional<T> validateExists(T entity) {
+        if (entity == null || entity.isDeleted()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(entity);
     }
 }

--- a/src/main/java/ktb3/full/week04/domain/base/Auditing.java
+++ b/src/main/java/ktb3/full/week04/domain/base/Auditing.java
@@ -1,11 +1,11 @@
-package ktb3.full.week04.domain;
+package ktb3.full.week04.domain.base;
 
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-public class Auditing {
+public abstract class Auditing {
 
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/ktb3/full/week04/dto/page/IdAndCreatedDate.java
+++ b/src/main/java/ktb3/full/week04/dto/page/IdAndCreatedDate.java
@@ -1,0 +1,15 @@
+package ktb3.full.week04.dto.page;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@EqualsAndHashCode
+@Getter
+@RequiredArgsConstructor
+public class IdAndCreatedDate {
+    private final long id;
+    private final LocalDateTime createdDate;
+}

--- a/src/main/java/ktb3/full/week04/dto/request/CommentCreateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/CommentCreateRequest.java
@@ -1,4 +1,20 @@
 package ktb3.full.week04.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import ktb3.full.week04.domain.Comment;
+import ktb3.full.week04.domain.Post;
+import ktb3.full.week04.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public class CommentCreateRequest {
+
+    @NotNull
+    private final String content;
+
+    public Comment toEntity(User user, Post post) {
+        return Comment.create(user, post, content);
+    }
 }

--- a/src/main/java/ktb3/full/week04/dto/request/CommentCreateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/CommentCreateRequest.java
@@ -1,17 +1,21 @@
 package ktb3.full.week04.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import ktb3.full.week04.common.annotation.constraint.CommentContentPattern;
 import ktb3.full.week04.domain.Comment;
 import ktb3.full.week04.domain.Post;
 import ktb3.full.week04.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import static ktb3.full.week04.common.Constants.MESSAGE_NOT_NULL_COMMENT_CONTENT;
+
 @Getter
 @RequiredArgsConstructor
 public class CommentCreateRequest {
 
-    @NotNull
+    @NotNull(message = MESSAGE_NOT_NULL_COMMENT_CONTENT)
+    @CommentContentPattern
     private final String content;
 
     public Comment toEntity(User user, Post post) {

--- a/src/main/java/ktb3/full/week04/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/CommentUpdateRequest.java
@@ -1,4 +1,11 @@
 package ktb3.full.week04.dto.request;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public class CommentUpdateRequest {
+
+    private final String content;
 }

--- a/src/main/java/ktb3/full/week04/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/ktb3/full/week04/dto/request/CommentUpdateRequest.java
@@ -1,5 +1,6 @@
 package ktb3.full.week04.dto.request;
 
+import ktb3.full.week04.common.annotation.constraint.CommentContentPattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,5 +8,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommentUpdateRequest {
 
+    @CommentContentPattern
     private final String content;
 }

--- a/src/main/java/ktb3/full/week04/dto/response/CommentResponse.java
+++ b/src/main/java/ktb3/full/week04/dto/response/CommentResponse.java
@@ -1,4 +1,33 @@
 package ktb3.full.week04.dto.response;
 
+
+import ktb3.full.week04.domain.Comment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
 public class CommentResponse {
+
+    private final long commentId;
+    private final long postId;
+    private final long userId;
+    private final String author;
+    private final String content;
+    private final LocalDateTime createdDate;
+
+    public static CommentResponse from(Comment comment) {
+        return builder()
+                .commentId(comment.getCommentId())
+                .postId(comment.getPost().getPostId())
+                .userId(comment.getUser().getUserId())
+                .author(comment.getUser().getNickname())
+                .content(comment.getContent())
+                .createdDate(comment.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/ktb3/full/week04/presentation/controller/CommentApiController.java
+++ b/src/main/java/ktb3/full/week04/presentation/controller/CommentApiController.java
@@ -1,12 +1,61 @@
 package ktb3.full.week04.presentation.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import ktb3.full.week04.common.annotation.resolver.Authentication;
+import ktb3.full.week04.dto.page.PageRequest;
+import ktb3.full.week04.dto.page.PageResponse;
+import ktb3.full.week04.dto.request.CommentCreateRequest;
+import ktb3.full.week04.dto.request.CommentUpdateRequest;
+import ktb3.full.week04.dto.response.ApiResponse;
+import ktb3.full.week04.dto.response.CommentResponse;
+import ktb3.full.week04.dto.session.LoggedInUser;
+import ktb3.full.week04.service.CommentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/posts/{postId}/comments")
 @RestController
 public class CommentApiController {
 
+    private final CommentService commentService;
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<PageResponse<CommentResponse>>> getAllComments(
+            @Valid PageRequest pageRequest,
+            @Positive @PathVariable("postId") long postId) {
+        PageResponse<CommentResponse> response = commentService.getAllComments(postId, pageRequest);
+        return ResponseEntity.ok()
+                .body(ApiResponse.of(response));
+    }
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<Void>> createComment(
+            @Authentication LoggedInUser loggedInUser,
+            @Positive @PathVariable("postId") long postId,
+            @Valid @RequestBody CommentCreateRequest request) {
+        commentService.createComment(loggedInUser.getUserId(), postId, request);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> updatePost(
+            @Authentication LoggedInUser loggedInUser,
+            @Positive @PathVariable("commentId") long commentId,
+            @Valid @RequestBody CommentUpdateRequest request) {
+        commentService.updateComment(loggedInUser.getUserId(), commentId, request);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @Authentication LoggedInUser loggedInUser,
+            @Positive @PathVariable("commentId") long commentId) {
+        commentService.deleteComment(loggedInUser.getUserId(), commentId);
+        return ResponseEntity.ok()
+                .body(ApiResponse.getBaseResponse());
+    }
 }

--- a/src/main/java/ktb3/full/week04/repository/CommentRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/CommentRepository.java
@@ -1,9 +1,12 @@
 package ktb3.full.week04.repository;
 
 import ktb3.full.week04.domain.Comment;
+import ktb3.full.week04.dto.page.PageRequest;
+import ktb3.full.week04.dto.page.PageResponse;
 import ktb3.full.week04.repository.base.CrudRepository;
 import ktb3.full.week04.repository.base.PagingAndSortingRepository;
 
 public interface CommentRepository extends CrudRepository<Comment, Long>, PagingAndSortingRepository<Comment> {
 
+    PageResponse<Comment> findAll(long postId, PageRequest pageRequest);
 }

--- a/src/main/java/ktb3/full/week04/repository/PostRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/PostRepository.java
@@ -1,8 +1,12 @@
 package ktb3.full.week04.repository;
 
 import ktb3.full.week04.domain.Post;
+import ktb3.full.week04.dto.page.PageRequest;
+import ktb3.full.week04.dto.page.PageResponse;
 import ktb3.full.week04.repository.base.CrudRepository;
 import ktb3.full.week04.repository.base.PagingAndSortingRepository;
 
 public interface PostRepository extends CrudRepository<Post, Long>, PagingAndSortingRepository<Post> {
+
+    PageResponse<Post> findAll(PageRequest pageRequest);
 }

--- a/src/main/java/ktb3/full/week04/repository/base/PagingAndSortingRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/base/PagingAndSortingRepository.java
@@ -1,9 +1,30 @@
 package ktb3.full.week04.repository.base;
 
+import ktb3.full.week04.dto.page.IdAndCreatedDate;
 import ktb3.full.week04.dto.page.PageRequest;
 import ktb3.full.week04.dto.page.PageResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public interface PagingAndSortingRepository<T> {
 
     PageResponse<T> findAll(PageRequest pageRequest);
+
+    default PageResponse<T> findAllByLatest(Map<Long, T> idToEntity, List<IdAndCreatedDate> latestEntities, PageRequest pageRequest) {
+        int pageNumber = pageRequest.getPage();
+        int pageSize = pageRequest.getSize();
+        int offset =  (pageNumber - 1) * pageSize;
+        int start = latestEntities.size() - offset - 1;
+        int end = Math.max(start - pageSize + 1, 0);
+
+        List<T> content = new ArrayList<>();
+        for (int i = start; i >= end; i--) {
+            IdAndCreatedDate pair = latestEntities.get(i);
+            content.add(idToEntity.get(pair.getId()));
+        }
+
+        return PageResponse.of(content, pageNumber, pageSize, end > 0);
+    }
 }

--- a/src/main/java/ktb3/full/week04/repository/base/PagingAndSortingRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/base/PagingAndSortingRepository.java
@@ -10,8 +10,6 @@ import java.util.Map;
 
 public interface PagingAndSortingRepository<T> {
 
-    PageResponse<T> findAll(PageRequest pageRequest);
-
     default PageResponse<T> findAllByLatest(Map<Long, T> idToEntity, List<IdAndCreatedDate> latestEntities, PageRequest pageRequest) {
         int pageNumber = pageRequest.getPage();
         int pageSize = pageRequest.getSize();

--- a/src/main/java/ktb3/full/week04/repository/impl/CommentMemoryRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/impl/CommentMemoryRepository.java
@@ -1,0 +1,60 @@
+package ktb3.full.week04.repository.impl;
+
+import ktb3.full.week04.domain.Comment;
+import ktb3.full.week04.dto.page.IdAndCreatedDate;
+import ktb3.full.week04.dto.page.PageRequest;
+import ktb3.full.week04.dto.page.PageResponse;
+import ktb3.full.week04.repository.CommentRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class CommentMemoryRepository implements CommentRepository {
+
+    private final AtomicLong commentIdCounter = new AtomicLong(1L);
+
+    private final Map<Long, Comment> idToComment = new ConcurrentHashMap<>();
+    private final List<IdAndCreatedDate> latestComments = new ArrayList<>();
+
+    @Override
+    public void save(Comment comment) {
+        long commentId = commentIdCounter.getAndIncrement();
+        comment.save(commentId);
+        idToComment.put(commentId, comment);
+        latestComments.add(new IdAndCreatedDate(commentId, comment.getCreatedAt()));
+    }
+
+    @Override
+    public void saveAll(Iterable<Comment> comments) {
+        comments.forEach(this::save);
+    }
+
+    @Override
+    public Optional<Comment> findById(Long commentId) {
+        Comment comment = idToComment.get(commentId);
+        return Comment.validateExists(comment);
+    }
+
+    @Override
+    public void update(Comment comment) {
+        idToComment.put(comment.getCommentId(), comment);
+    }
+
+    @Override
+    public void delete(Comment comment) {
+        // soft delete
+        idToComment.put(comment.getCommentId(), comment);
+        latestComments.remove(new IdAndCreatedDate(comment.getCommentId(), comment.getCreatedAt()));
+    }
+
+    @Override
+    public PageResponse<Comment> findAll(PageRequest pageRequest) {
+        return this.findAllByLatest(idToComment, latestComments, pageRequest);
+    }
+}

--- a/src/main/java/ktb3/full/week04/repository/impl/CommentMemoryRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/impl/CommentMemoryRepository.java
@@ -55,7 +55,7 @@ public class CommentMemoryRepository implements CommentRepository {
     public void delete(Comment comment) {
         // soft delete
         idToComment.put(comment.getCommentId(), comment);
-        postIdToLatestComments.remove(comment.getPost().getPostId()).remove(new IdAndCreatedDate(comment.getCommentId(), comment.getCreatedAt()));
+        postIdToLatestComments.get(comment.getPost().getPostId()).remove(new IdAndCreatedDate(comment.getCommentId(), comment.getCreatedAt()));
     }
 
     @Override

--- a/src/main/java/ktb3/full/week04/repository/impl/PostMemoryRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/impl/PostMemoryRepository.java
@@ -45,7 +45,7 @@ public class PostMemoryRepository implements PostRepository {
     @Override
     public Optional<Post> findById(Long postId) {
         Post post = idToPost.get(postId);
-        return validatePost(post);
+        return Post.validateExists(post);
     }
 
     @Override
@@ -71,14 +71,6 @@ public class PostMemoryRepository implements PostRepository {
         // soft delete
         idToPost.put(post.getPostId(), post);
         latestPosts.remove(new PostIdAndCreatedDate(post.getPostId(), post.getCreatedAt()));
-    }
-
-    private static Optional<Post> validatePost(Post post) {
-        if (post == null || post.isDeleted()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(post);
     }
 
     @EqualsAndHashCode

--- a/src/main/java/ktb3/full/week04/repository/impl/UserMemoryRepository.java
+++ b/src/main/java/ktb3/full/week04/repository/impl/UserMemoryRepository.java
@@ -46,7 +46,7 @@ public class UserMemoryRepository implements UserRepository {
     @Override
     public Optional<User> findById(Long userId) {
         User user = idToUser.get(userId);
-        return validateUser(user);
+        return User.validateExists(user);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class UserMemoryRepository implements UserRepository {
             return Optional.empty();
         }
 
-        return validateUser(idToUser.get(userId));
+        return User.validateExists(idToUser.get(userId));
     }
 
     @Override
@@ -76,13 +76,5 @@ public class UserMemoryRepository implements UserRepository {
         idToUser.remove(user.getUserId());
         emailToId.remove(user.getEmail());
         nicknameToId.remove(user.getNickname());
-    }
-
-    private static Optional<User> validateUser(User user) {
-        if (user == null || user.isDeleted()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(user);
     }
 }

--- a/src/main/java/ktb3/full/week04/service/CommentService.java
+++ b/src/main/java/ktb3/full/week04/service/CommentService.java
@@ -10,11 +10,11 @@ import ktb3.full.week04.service.base.Findable;
 
 public interface CommentService extends Findable<Comment, Long> {
 
-    PageResponse<CommentResponse> getAllComments(Long postId, PageRequest pageRequest);
+    PageResponse<CommentResponse> getAllComments(long postId, PageRequest pageRequest);
 
-    void createComment(Long postId, CommentCreateRequest request);
+    void createComment(long userId, long postId, CommentCreateRequest request);
 
-    void updateComment(Long userId, Long commentId, CommentUpdateRequest request);
+    void updateComment(long userId, long commentId, CommentUpdateRequest request);
 
-    void deleteComment(Long userId, Long commentId);
+    void deleteComment(long userId, long commentId);
 }

--- a/src/main/java/ktb3/full/week04/service/impl/CommentServiceImpl.java
+++ b/src/main/java/ktb3/full/week04/service/impl/CommentServiceImpl.java
@@ -29,7 +29,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public PageResponse<CommentResponse> getAllComments(long postId, PageRequest pageRequest) {
-        PageResponse<Comment> commentsPageResponse = commentRepository.findAll(pageRequest);
+        PageResponse<Comment> commentsPageResponse = commentRepository.findAll(postId, pageRequest);
         List<CommentResponse> responses = commentsPageResponse.getContent().stream().map(CommentResponse::from).toList();
 
         return PageResponse.of(responses, commentsPageResponse.getPage(), commentsPageResponse.getSize(), commentsPageResponse.isHasNext());

--- a/src/main/java/ktb3/full/week04/service/impl/CommentServiceImpl.java
+++ b/src/main/java/ktb3/full/week04/service/impl/CommentServiceImpl.java
@@ -1,0 +1,73 @@
+package ktb3.full.week04.service.impl;
+
+import ktb3.full.week04.common.exception.CommentNotFoundException;
+import ktb3.full.week04.common.exception.base.NotFoundException;
+import ktb3.full.week04.domain.Comment;
+import ktb3.full.week04.domain.Post;
+import ktb3.full.week04.domain.User;
+import ktb3.full.week04.dto.page.PageRequest;
+import ktb3.full.week04.dto.page.PageResponse;
+import ktb3.full.week04.dto.request.CommentCreateRequest;
+import ktb3.full.week04.dto.request.CommentUpdateRequest;
+import ktb3.full.week04.dto.response.CommentResponse;
+import ktb3.full.week04.repository.CommentRepository;
+import ktb3.full.week04.service.CommentService;
+import ktb3.full.week04.service.PostService;
+import ktb3.full.week04.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserService userService;
+    private final PostService postService;
+
+    @Override
+    public PageResponse<CommentResponse> getAllComments(long postId, PageRequest pageRequest) {
+        PageResponse<Comment> commentsPageResponse = commentRepository.findAll(pageRequest);
+        List<CommentResponse> responses = commentsPageResponse.getContent().stream().map(CommentResponse::from).toList();
+
+        return PageResponse.of(responses, commentsPageResponse.getPage(), commentsPageResponse.getSize(), commentsPageResponse.isHasNext());
+    }
+
+    @Override
+    public void createComment(long userId, long postId, CommentCreateRequest request) {
+        User user = userService.getOrThrow(userId);
+        Post post = postService.getOrThrow(postId);
+        Comment comment = request.toEntity(user, post);
+
+        commentRepository.save(comment);
+    }
+
+    @Override
+    public void updateComment(long userId, long commentId, CommentUpdateRequest request) {
+        Comment comment = getOrThrow(commentId);
+        userService.validatePermission(userId, comment.getUser().getUserId());
+
+        if (request.getContent() != null) {
+            comment.updateContent(request.getContent());
+        }
+
+        commentRepository.update(comment);
+    }
+
+    @Override
+    public void deleteComment(long userId, long commentId) {
+        Comment comment = getOrThrow(commentId);
+        userService.validatePermission(userId, comment.getUser().getUserId());
+        comment.delete();
+
+        commentRepository.delete(comment);
+    }
+
+    @Override
+    public Comment getOrThrow(Long commentId) throws NotFoundException {
+        return commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+    }
+}


### PR DESCRIPTION
### 작업 내용
- `Auditing` 클래스 공통 로직 추가
  - 하위 엔티티에서 공통적으로 사용되는 로직을 재사용할 수 있게 만들었습니다.

- `PagingAndSortingRepository` 인터페이스 공통 로직 추가
  - 구현 클래스에서 공통적으로 사용되는 페이징 처리 로직을 재사용할 수 있게 만들었습니다.

- `CommentMemoryRepository` 구현
  - 게시글 내 댓글만 조회되도록 `Map` 자료구조의 저장소를 추가했습니다.